### PR TITLE
Add DeepBGC output parsing support

### DIFF
--- a/RRE.py
+++ b/RRE.py
@@ -83,16 +83,14 @@ def find_gbk_clusters(all_seqs,req_type=False):
                 product_classes = quals.get('product_class', [])
                 if products:
                     cluster_type = product[0]
-                    cluster_types = cluster_type.split('-')
                 elif product_classes:
                     cluster_type = product_classes[0]
-                    cluster_types = cluster_type.split(',')
                 else:
                     cluster_type = ''
-                    cluster_types = []
                 if req_type:
                     # Only parse clusters of the required types
                     # Only used for now with the RiPP types
+                    cluster_types = cluster_type.split('-')
                     if not any([c in req_type for c in cluster_types]):
                         continue
                 notes = quals.get('note')


### PR DESCRIPTION
Hi guys!

I wanted to use your tool to analyse outputs of our DeepBGC method.

It turns out it was actually pretty simple, since our output mostly follows the output format of antiSMASH (before version 5). 

Would you consider adding these changes to your master branch version?

Here is the usage:
```bash
# RiPP only
python RRE.py -i mibig_example_deepbgc_0.1.8.full.gbk --deepbgc ripp --mode precision deepbgc_ripp        

# Reading in file mibig_example_deepbgc_0.1.8.full.gbk
# Continuing with 150 queries
# Rewriting fasta
# hmmsearch --cpu 1 -o output/deepbgc_ripp/results/RREfam_hmm_results.txt --domtblout output/deepbgc_ripp/results/RREfam_hmm_results.tbl -T 25 data/hmm/RREFam_v4.hmm output/deepbgc_ripp/fastas/fasta_all.fasta
# Finished. Total time: 2.83 seconds (on 1 cores)
# RREFam hits found: 8 out of 150

# All clusters
python RRE.py -i mibig_example_deepbgc_0.1.8.full.gbk --deepbgc clusters --mode precision deepbgc_clusters

# Reading in file mibig_example_deepbgc_0.1.8.full.gbk
# Continuing with 2964 queries
# Rewriting fasta
# hmmsearch --cpu 1 -o output/deepbgc_clusters/results/RREfam_hmm_results.txt --domtblout output/deepbgc_clusters/results/RREfam_hmm_results.tbl -T 25 data/hmm/RREFam_v4.hmm output/deepbgc_clusters/fastas/fasta_all.fasta
# Finished. Total time: 4.64 seconds (on 1 cores)
# RREFam hits found: 8 out of 2964

# All genes
python RRE.py -i mibig_example_deepbgc_0.1.8.full.gbk --deepbgc all --mode precision deepbgc_all          

# Reading in file mibig_example_deepbgc_0.1.8.full.gbk
# Continuing with 3265 queries
# Rewriting fasta
# hmmsearch --cpu 1 -o output/deepbgc_all/results/RREfam_hmm_results.txt --domtblout output/deepbgc_all/results/RREfam_hmm_results.tbl -T 25 data/hmm/RREFam_v4.hmm output/deepbgc_all/fastas/fasta_all.fasta
# Finished. Total time: 4.70 seconds (on 1 cores)
# RREFam hits found: 8 out of 3265
```
Input file:
[mibig_example_deepbgc_0.1.8.full.gbk.gz](https://github.com/Alexamk/RREFinder/files/4403711/mibig_example_deepbgc_0.1.8.full.gbk.gz)

Our publication:
A deep learning genome-mining strategy for biosynthetic gene cluster prediction, Geoffrey D Hannigan,  David Prihoda et al., Nucleic Acids Research, gkz654, https://doi.org/10.1093/nar/gkz654
